### PR TITLE
fix: maul copy of code

### DIFF
--- a/src/pages/SuccessPage.tsx
+++ b/src/pages/SuccessPage.tsx
@@ -30,25 +30,21 @@ const useDebounceClick = () => {
 	};
 };
 
-const getAppUrl = () => {
-	const { code } = queryParams();
-	const protocol = import.meta.env.VITE_APP_PROTOCOL;
-	const url = `${protocol}://browser-auth?code=${code}`;
-	return url;
-};
-
 const SuccessPage: FC = () => {
 	const { wasClicked: wasCopied, debounceClick } = useDebounceClick();
+	const { code } = queryParams();
 
 	useEffect(() => {
 		// Open the desktop app (if installed) with the necessary code for login
-		window.location.href = getAppUrl();
+		const protocol = import.meta.env.VITE_APP_PROTOCOL;
+		const url = `${protocol}://browser-auth?code=${code}`;
+		window.location.href = url;
 	}, []);
 
 	const handleOnclick = () => {
 		debounceClick();
 		// Write the login code to the clipboard
-		navigator.clipboard.writeText(getAppUrl());
+		navigator.clipboard.writeText(code);
 	};
 
 	return (


### PR DESCRIPTION
Old behaviour: when a user clicked the copy code button they would get the app url with the code as query param.

Now: the user will just copy the code when clicking the copy code button.